### PR TITLE
post-fix slot to match slot naming convention

### DIFF
--- a/src/openmrs.ts
+++ b/src/openmrs.ts
@@ -14,7 +14,7 @@ function setupOpenMRS() {
     extensions: [
       {
         id: 'form-widget',
-        slot: 'form-widget',
+        slot: 'form-widget-slot',
         load: () => import('./main.single-spa'),
       },
     ],


### PR DESCRIPTION
### What does this PR do?

- [x] Post fix `slot` to extensionSlotName to comply with conventions 